### PR TITLE
feat:Add Team

### DIFF
--- a/app/components/InviteForm.tsx
+++ b/app/components/InviteForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCreateTeamMember, useFindManyUser } from "@/generated/hooks";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+interface Iprops {
+  teamId: string;
+}
+
+const InviteForm = (props: Iprops) => {
+  const { teamId } = props;
+  const queryClient = useQueryClient();
+  const [userId, setUserId] = useState("");
+
+  const { data: users } = useFindManyUser();
+
+  const { mutate: createMember } = useCreateTeamMember({
+    meta: {
+      readResult: false,
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["teamMembers"] });
+      setUserId("");
+      console.log("成功邀请成员");
+    },
+  });
+
+  const handleInvite = () => {
+    if (!userId.trim()) {
+      alert("请输入用户ID");
+      return;
+    }
+
+    if (!users?.some((user) => user.id === userId)) {
+      alert("用户不存在");
+      return;
+    }
+
+    createMember({
+      data: {
+        teamId: teamId,
+        userId: userId,
+        role: "MEMBER",
+      },
+    });
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="输入用户ID"
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+      />
+      <button onClick={handleInvite}>邀请成员</button>
+    </div>
+  );
+};
+
+export default InviteForm;

--- a/app/components/JoinTeamRequest.tsx
+++ b/app/components/JoinTeamRequest.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCreateTeamRequest, useFindManyTeam } from "@/generated/hooks";
+import { useState } from "react";
+
+interface IProps {
+  userId: string;
+}
+
+const JoinTeamRequest = ({ userId }: IProps) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [message, setMessage] = useState("");
+
+  const { data: teams = [] } = useFindManyTeam();
+  const { mutate: createRequest } = useCreateTeamRequest({
+    onSuccess: () => {
+      console.log("申请已提交");
+      setMessage("");
+    },
+  });
+
+  const handleJoinTeam = (teamId: string) => {
+    createRequest({
+      data: {
+        teamId: teamId,
+        requesterId: userId,
+        message: message,
+        status: "pending",
+      },
+    });
+  };
+
+  return (
+    <div className="join-team">
+      <hr />
+      <h3>申请加入团队</h3>
+      <input
+        type="text"
+        placeholder="搜索团队名称"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+      />
+      <div className="team-results">
+        {teams
+          .filter(
+            (team) =>
+              team.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+              team.createdById !== userId
+          )
+          .map((team) => (
+            <div key={team.id} className="team-item">
+              <span>{team.name}</span>
+              <input
+                type="text"
+                placeholder="留言（可选）"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+              />
+              <button
+                onClick={() => {
+                  handleJoinTeam(team.id);
+                }}
+              >
+                申请加入
+              </button>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default JoinTeamRequest;

--- a/app/components/TeamList.tsx
+++ b/app/components/TeamList.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useFindManyTeam } from "@/generated/hooks";
+import InviteForm from "./InviteForm";
+import TeamRequests from "./TeamRequests ";
+import TeamTodo from "./TeamTodo";
+
+interface Iprops {
+  userId: string;
+}
+
+const TeamList = (props: Iprops) => {
+  const { userId } = props;
+  const { data: teams = [] } = useFindManyTeam({
+    where: {
+      OR: [
+        { createdById: userId },
+        {
+          members: {
+            some: { userId },
+          },
+        },
+      ],
+    },
+    include: {
+      members: true,
+      createdBy: true,
+    },
+  });
+
+  return (
+    <div>
+      {teams.map((team) => (
+        <li key={team.id}>
+          {team.name}
+
+          <TeamTodo userId={userId} teamId={team.id} />
+          <InviteForm teamId={team.id} />
+          <TeamRequests teamId={team.id} />
+        </li>
+      ))}
+    </div>
+  );
+};
+export default TeamList;

--- a/app/components/TeamManagement.tsx
+++ b/app/components/TeamManagement.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useCreateTeam, useCreateTeamMember } from "@/generated/hooks";
+import React, { useState } from "react";
+import TeamList from "./TeamList";
+
+interface Iprops {
+  userId: string;
+}
+
+const TeamManagement = (props: Iprops) => {
+  const { userId } = props;
+  const [TeamName, setTeamName] = useState("");
+
+  const { mutate: createTeam } = useCreateTeam({
+    onSuccess: (newTeam) => {
+      createTeamMember({
+        data: {
+          teamId: newTeam!.id,
+          userId: userId,
+          role: "ADMIN",
+        },
+      });
+      setTeamName("");
+    },
+  });
+
+  const handleTeamNameKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (TeamName === "") {
+      return;
+    }
+    if (event.key === "Enter") {
+      createTeam({
+        data: {
+          name: TeamName.trim(),
+          createdById: userId,
+        },
+      });
+    }
+  };
+
+  const { mutate: createTeamMember } = useCreateTeamMember();
+
+  return (
+    <div>
+      <hr />
+      <h3>团队管理</h3>
+      <input
+        type="text"
+        placeholder="请创建团队名称"
+        onChange={(e) => setTeamName(e.target.value)}
+        value={TeamName}
+        onKeyDown={handleTeamNameKeyDown}
+      />
+
+      <TeamList userId={userId}></TeamList>
+    </div>
+  );
+};
+
+export default TeamManagement;

--- a/app/components/TeamRequests .tsx
+++ b/app/components/TeamRequests .tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  useCreateTeamMember,
+  useFindManyTeamRequest,
+  useUpdateManyTeamRequest,
+} from "@/generated/hooks";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface Iprops {
+  teamId: string;
+}
+
+interface CustomError extends Error {
+  code?: string;
+}
+const TeamRequests = (props: Iprops) => {
+  const queryClient = useQueryClient();
+  const { teamId } = props;
+  const { mutate: createMember } = useCreateTeamMember();
+
+  const { data: requests = [] } = useFindManyTeamRequest({
+    where: { teamId: teamId, status: "pending" },
+  });
+
+  const { mutate: updateRequest } = useUpdateManyTeamRequest();
+  function isCustomError(error: unknown): error is CustomError {
+    return error instanceof Error && "code" in error;
+  }
+
+  const handleApprove = (requestId: string, requesterId: string) => {
+    try {
+      updateRequest({
+        where: { id: requestId },
+        data: { status: { set: "approved" } },
+      });
+
+      createMember({
+        data: {
+          teamId: teamId,
+          userId: requesterId,
+          role: "MEMBER",
+        },
+      });
+      queryClient.invalidateQueries({ queryKey: ["teamTodos"] });
+      queryClient.invalidateQueries({ queryKey: ["team"] });
+    } catch (error) {
+      if (isCustomError(error) && error.code === "P2004") {
+        alert("您不是管理员，需要管理员才能进行操作");
+      }
+    }
+  };
+
+  const handleRejected = (requesterId: string) => {
+    try {
+      updateRequest({
+        where: { id: requesterId },
+        data: { status: { set: "rejected" } },
+      });
+
+      queryClient.invalidateQueries({ queryKey: ["teamTodos"] });
+      queryClient.invalidateQueries({ queryKey: ["team"] });
+    } catch (error) {
+      if (isCustomError(error) && error.code === "P2004") {
+        alert("您不是管理员，需要管理员才能进行操作");
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h5>待处理的加入申请</h5>
+      {requests.map((request) => (
+        <div key={request.id}>
+          <span>用户{request.requesterId}申请加入</span>
+          <button
+            onClick={() => handleApprove(request.id, request.requesterId)}
+          >
+            通过
+          </button>
+          <button onClick={() => handleRejected(request.id)}>拒绝</button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TeamRequests;

--- a/app/components/TeamTodo.tsx
+++ b/app/components/TeamTodo.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import {
+  useCreateTeamTodos,
+  useDeleteTeamTodos,
+  useFindManyTeamTodos,
+  useUpdateTeamTodos,
+} from "@/generated/hooks";
+import { useQueryClient } from "@tanstack/react-query";
+import React, { useState } from "react";
+
+interface Iprops {
+  userId: string;
+  teamId: string;
+}
+const TeamTodo = (props: Iprops) => {
+  const { userId, teamId } = props;
+  const queryClient = useQueryClient();
+  console.log("[TeamTodo] 当前用户ID:", userId);
+  const [inputTeamValue, setInputTeamValue] = useState("");
+
+  const { data: teamTodos = [] } = useFindManyTeamTodos({
+    where: {
+      teamId: teamId,
+    },
+    include: {
+      team: {
+        include: {
+          members: true,
+        },
+      },
+    },
+  });
+  console.log("[TeamTodo] 获取到的数据:", teamTodos);
+
+  const { mutate: createTeamTodo } = useCreateTeamTodos({
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["teamTodos", { teamId }],
+      });
+      setInputTeamValue("");
+    },
+  });
+
+  const handleTeamKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (inputTeamValue === "") {
+      return;
+    }
+    if (event.key === "Enter" && inputTeamValue.trim()) {
+      createTeamTodo({
+        data: {
+          name: inputTeamValue.trim(),
+          creatorId: userId,
+          teamId: teamId,
+        },
+      });
+      setInputTeamValue("");
+    }
+  };
+
+  const { mutate: deleteTeamTodo } = useDeleteTeamTodos({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["teamTodos", { teamId }] });
+    },
+  });
+
+  const { mutate: updateTeamTodo } = useUpdateTeamTodos({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["teamTodos", { teamId }] });
+    },
+  });
+
+  const count = teamTodos.filter((teamTodo) => !teamTodo.completed).length;
+
+  return (
+    <div>
+      <h3>团队代办事项</h3>
+      <input
+        type="text"
+        placeholder="添加团队任务"
+        onChange={(e) => setInputTeamValue(e.target.value)}
+        value={inputTeamValue}
+        onKeyDown={handleTeamKeyDown}
+      />
+      <ul>
+        {teamTodos.map((teamTodo) => (
+          <li key={teamTodo.id}>
+            <span>{teamTodo.name}</span>
+            <span>(创建者:{teamTodo.creatorId})</span>
+            <span
+              className={`todo_item ${teamTodo.completed ? "todo_item_active" : ""}`}
+              onClick={() =>
+                updateTeamTodo({
+                  where: { id: teamTodo.id },
+                  data: { completed: !teamTodo.completed },
+                })
+              }
+            ></span>
+            <button
+              onClick={() => {
+                deleteTeamTodo({
+                  where: { id: teamTodo.id },
+                });
+              }}
+            >
+              删除
+            </button>
+          </li>
+        ))}
+      </ul>
+      <span>还有 {count} 个未完成</span>
+    </div>
+  );
+};
+
+export default TeamTodo;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,9 @@ import SearchUser from "./components/SearchUser";
 import Request from "./components/Request";
 
 import Image from "next/image";
+import TeamManagement from "./components/TeamManagement";
+import JoinTeamRequest from "./components/JoinTeamRequest";
+
 
 export interface Todo {
   id: number;
@@ -69,7 +72,10 @@ export default async function Home() {
         </ul>
         <SearchUser currentUserId={claims?.sub || ""} />
         <Request currentUserId={claims?.sub || ""} />
+      <TeamManagement userId={claims?.sub || ""}/>
+      <JoinTeamRequest userId={claims?.sub || ""} />
       </div>
     </div>
   );
 }
+  

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,6 +9,14 @@ tags:
     description: Todos operations
   - name: request
     description: Request operations
+  - name: teamTodos
+    description: TeamTodos operations
+  - name: team
+    description: Team operations
+  - name: teamMember
+    description: TeamMember operations
+  - name: teamRequest
+    description: TeamRequest operations
 components:
   schemas:
     RequestStatus:
@@ -17,6 +25,11 @@ components:
         - pending
         - approved
         - rejected
+    TeamRole:
+      type: string
+      enum:
+        - MEMBER
+        - ADMIN
     UserScalarFieldEnum:
       type: string
       enum:
@@ -34,12 +47,45 @@ components:
       type: string
       enum:
         - id
-        - requesterId
-        - targetUserId
-        - status
         - message
         - createdAt
         - updatedAt
+        - requesterId
+        - targetUserId
+        - status
+    TeamTodosScalarFieldEnum:
+      type: string
+      enum:
+        - id
+        - name
+        - completed
+        - createdAt
+        - creatorId
+        - teamId
+    TeamScalarFieldEnum:
+      type: string
+      enum:
+        - id
+        - name
+        - createdAt
+        - createdById
+    TeamMemberScalarFieldEnum:
+      type: string
+      enum:
+        - id
+        - teamId
+        - userId
+        - role
+    TeamRequestScalarFieldEnum:
+      type: string
+      enum:
+        - id
+        - message
+        - createdAt
+        - updatedAt
+        - teamId
+        - requesterId
+        - status
     SortOrder:
       type: string
       enum:
@@ -76,6 +122,22 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Request"
+        teamMember:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMember"
+        createTeamTodos:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodos"
+        ownedTeams:
+          type: array
+          items:
+            $ref: "#/components/schemas/Team"
+        teamRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequest"
       required:
         - id
     Todos:
@@ -106,16 +168,6 @@ components:
       properties:
         id:
           type: string
-        requester:
-          $ref: "#/components/schemas/User"
-        requesterId:
-          type: string
-        targetUser:
-          $ref: "#/components/schemas/User"
-        targetUserId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -126,15 +178,142 @@ components:
         updatedAt:
           type: string
           format: date-time
+        requester:
+          $ref: "#/components/schemas/User"
+        requesterId:
+          type: string
+        targetUser:
+          $ref: "#/components/schemas/User"
+        targetUserId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - id
+        - createdAt
+        - updatedAt
         - requester
         - requesterId
         - targetUser
         - targetUserId
         - status
+    TeamTodos:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creator:
+          $ref: "#/components/schemas/User"
+        creatorId:
+          type: string
+        team:
+          $ref: "#/components/schemas/Team"
+        teamId:
+          type: string
+      required:
+        - id
+        - name
+        - completed
+        - createdAt
+        - creator
+        - creatorId
+        - team
+        - teamId
+    Team:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/User"
+        createdById:
+          type: string
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMember"
+        todos:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodos"
+        requests:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequest"
+      required:
+        - id
+        - name
+        - createdAt
+        - createdBy
+        - createdById
+    TeamMember:
+      type: object
+      properties:
+        id:
+          type: string
+        team:
+          $ref: "#/components/schemas/Team"
+        teamId:
+          type: string
+        user:
+          $ref: "#/components/schemas/User"
+        userId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - id
+        - team
+        - teamId
+        - user
+        - userId
+        - role
+    TeamRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        team:
+          $ref: "#/components/schemas/Team"
+        teamId:
+          type: string
+        requester:
+          $ref: "#/components/schemas/User"
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - id
         - createdAt
         - updatedAt
+        - team
+        - teamId
+        - requester
+        - requesterId
+        - status
     UserWhereInput:
       type: object
       properties:
@@ -169,6 +348,14 @@ components:
           $ref: "#/components/schemas/RequestListRelationFilter"
         receivedRequests:
           $ref: "#/components/schemas/RequestListRelationFilter"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberListRelationFilter"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosListRelationFilter"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamListRelationFilter"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestListRelationFilter"
     UserOrderByWithRelationInput:
       type: object
       properties:
@@ -184,6 +371,14 @@ components:
           $ref: "#/components/schemas/RequestOrderByRelationAggregateInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestOrderByRelationAggregateInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberOrderByRelationAggregateInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosOrderByRelationAggregateInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamOrderByRelationAggregateInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestOrderByRelationAggregateInput"
     UserWhereUniqueInput:
       type: object
       properties:
@@ -216,6 +411,14 @@ components:
           $ref: "#/components/schemas/RequestListRelationFilter"
         receivedRequests:
           $ref: "#/components/schemas/RequestListRelationFilter"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberListRelationFilter"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosListRelationFilter"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamListRelationFilter"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestListRelationFilter"
     UserScalarWhereWithAggregatesInput:
       type: object
       properties:
@@ -408,18 +611,6 @@ components:
           oneOf:
             - $ref: "#/components/schemas/StringFilter"
             - type: string
-        requesterId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        targetUserId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/EnumRequestStatusFilter"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - $ref: "#/components/schemas/StringNullableFilter"
@@ -435,6 +626,18 @@ components:
             - $ref: "#/components/schemas/DateTimeFilter"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        targetUserId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
         requester:
           oneOf:
             - $ref: "#/components/schemas/UserScalarRelationFilter"
@@ -448,12 +651,6 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/SortOrder"
-        requesterId:
-          $ref: "#/components/schemas/SortOrder"
-        targetUserId:
-          $ref: "#/components/schemas/SortOrder"
-        status:
-          $ref: "#/components/schemas/SortOrder"
         message:
           oneOf:
             - $ref: "#/components/schemas/SortOrder"
@@ -461,6 +658,12 @@ components:
         createdAt:
           $ref: "#/components/schemas/SortOrder"
         updatedAt:
+          $ref: "#/components/schemas/SortOrder"
+        requesterId:
+          $ref: "#/components/schemas/SortOrder"
+        targetUserId:
+          $ref: "#/components/schemas/SortOrder"
+        status:
           $ref: "#/components/schemas/SortOrder"
         requester:
           $ref: "#/components/schemas/UserOrderByWithRelationInput"
@@ -487,18 +690,6 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestWhereInput"
-        requesterId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        targetUserId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/EnumRequestStatusFilter"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - $ref: "#/components/schemas/StringNullableFilter"
@@ -514,6 +705,18 @@ components:
             - $ref: "#/components/schemas/DateTimeFilter"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        targetUserId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
         requester:
           oneOf:
             - $ref: "#/components/schemas/UserScalarRelationFilter"
@@ -545,18 +748,6 @@ components:
           oneOf:
             - $ref: "#/components/schemas/StringWithAggregatesFilter"
             - type: string
-        requesterId:
-          oneOf:
-            - $ref: "#/components/schemas/StringWithAggregatesFilter"
-            - type: string
-        targetUserId:
-          oneOf:
-            - $ref: "#/components/schemas/StringWithAggregatesFilter"
-            - type: string
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/EnumRequestStatusWithAggregatesFilter"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - $ref: "#/components/schemas/StringNullableWithAggregatesFilter"
@@ -572,6 +763,647 @@ components:
             - $ref: "#/components/schemas/DateTimeWithAggregatesFilter"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        targetUserId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusWithAggregatesFilter"
+            - $ref: "#/components/schemas/RequestStatus"
+    TeamTodosWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodosWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        completed:
+          oneOf:
+            - $ref: "#/components/schemas/BoolFilter"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        creator:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+    TeamTodosOrderByWithRelationInput:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/SortOrder"
+        name:
+          $ref: "#/components/schemas/SortOrder"
+        completed:
+          $ref: "#/components/schemas/SortOrder"
+        createdAt:
+          $ref: "#/components/schemas/SortOrder"
+        creatorId:
+          $ref: "#/components/schemas/SortOrder"
+        teamId:
+          $ref: "#/components/schemas/SortOrder"
+        creator:
+          $ref: "#/components/schemas/UserOrderByWithRelationInput"
+        team:
+          $ref: "#/components/schemas/TeamOrderByWithRelationInput"
+    TeamTodosWhereUniqueInput:
+      type: object
+      properties:
+        id:
+          type: string
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodosWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereInput"
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        completed:
+          oneOf:
+            - $ref: "#/components/schemas/BoolFilter"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        creator:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+    TeamTodosScalarWhereWithAggregatesInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        completed:
+          oneOf:
+            - $ref: "#/components/schemas/BoolWithAggregatesFilter"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeWithAggregatesFilter"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+    TeamWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        createdBy:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberListRelationFilter"
+        todos:
+          $ref: "#/components/schemas/TeamTodosListRelationFilter"
+        requests:
+          $ref: "#/components/schemas/TeamRequestListRelationFilter"
+    TeamOrderByWithRelationInput:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/SortOrder"
+        name:
+          $ref: "#/components/schemas/SortOrder"
+        createdAt:
+          $ref: "#/components/schemas/SortOrder"
+        createdById:
+          $ref: "#/components/schemas/SortOrder"
+        createdBy:
+          $ref: "#/components/schemas/UserOrderByWithRelationInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberOrderByRelationAggregateInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosOrderByRelationAggregateInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestOrderByRelationAggregateInput"
+    TeamWhereUniqueInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereInput"
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        createdBy:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberListRelationFilter"
+        todos:
+          $ref: "#/components/schemas/TeamTodosListRelationFilter"
+        requests:
+          $ref: "#/components/schemas/TeamRequestListRelationFilter"
+    TeamScalarWhereWithAggregatesInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeWithAggregatesFilter"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+    TeamMemberWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMemberWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        userId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/EnumTeamRoleFilter"
+            - $ref: "#/components/schemas/TeamRole"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+        user:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+    TeamMemberOrderByWithRelationInput:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/SortOrder"
+        teamId:
+          $ref: "#/components/schemas/SortOrder"
+        userId:
+          $ref: "#/components/schemas/SortOrder"
+        role:
+          $ref: "#/components/schemas/SortOrder"
+        team:
+          $ref: "#/components/schemas/TeamOrderByWithRelationInput"
+        user:
+          $ref: "#/components/schemas/UserOrderByWithRelationInput"
+    TeamMemberWhereUniqueInput:
+      type: object
+      properties:
+        id:
+          type: string
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMemberWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereInput"
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        userId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/EnumTeamRoleFilter"
+            - $ref: "#/components/schemas/TeamRole"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+        user:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+    TeamMemberScalarWhereWithAggregatesInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        userId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/EnumTeamRoleWithAggregatesFilter"
+            - $ref: "#/components/schemas/TeamRole"
+    TeamRequestWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequestWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        message:
+          oneOf:
+            - $ref: "#/components/schemas/StringNullableFilter"
+            - type: string
+            - type: "null"
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+        requester:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+    TeamRequestOrderByWithRelationInput:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/SortOrder"
+        message:
+          oneOf:
+            - $ref: "#/components/schemas/SortOrder"
+            - $ref: "#/components/schemas/SortOrderInput"
+        createdAt:
+          $ref: "#/components/schemas/SortOrder"
+        updatedAt:
+          $ref: "#/components/schemas/SortOrder"
+        teamId:
+          $ref: "#/components/schemas/SortOrder"
+        requesterId:
+          $ref: "#/components/schemas/SortOrder"
+        status:
+          $ref: "#/components/schemas/SortOrder"
+        team:
+          $ref: "#/components/schemas/TeamOrderByWithRelationInput"
+        requester:
+          $ref: "#/components/schemas/UserOrderByWithRelationInput"
+    TeamRequestWhereUniqueInput:
+      type: object
+      properties:
+        id:
+          type: string
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequestWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereInput"
+        message:
+          oneOf:
+            - $ref: "#/components/schemas/StringNullableFilter"
+            - type: string
+            - type: "null"
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
+        team:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarRelationFilter"
+            - $ref: "#/components/schemas/TeamWhereInput"
+        requester:
+          oneOf:
+            - $ref: "#/components/schemas/UserScalarRelationFilter"
+            - $ref: "#/components/schemas/UserWhereInput"
+    TeamRequestScalarWhereWithAggregatesInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        message:
+          oneOf:
+            - $ref: "#/components/schemas/StringNullableWithAggregatesFilter"
+            - type: string
+            - type: "null"
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeWithAggregatesFilter"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeWithAggregatesFilter"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringWithAggregatesFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusWithAggregatesFilter"
+            - $ref: "#/components/schemas/RequestStatus"
     UserCreateInput:
       type: object
       properties:
@@ -587,6 +1419,14 @@ components:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
       required:
         - id
     UserUpdateInput:
@@ -607,6 +1447,14 @@ components:
           $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
     UserCreateManyInput:
       type: object
       properties:
@@ -711,8 +1559,6 @@ components:
       properties:
         id:
           type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -723,6 +1569,8 @@ components:
         updatedAt:
           type: string
           format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
         requester:
           $ref: "#/components/schemas/UserCreateNestedOneWithoutSentRequestsInput"
         targetUser:
@@ -738,10 +1586,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -757,6 +1601,10 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         requester:
           $ref: "#/components/schemas/UserUpdateOneRequiredWithoutSentRequestsNestedInput"
         targetUser:
@@ -767,12 +1615,6 @@ components:
       properties:
         id:
           type: string
-        requesterId:
-          type: string
-        targetUserId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -783,6 +1625,12 @@ components:
         updatedAt:
           type: string
           format: date-time
+        requesterId:
+          type: string
+        targetUserId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - requesterId
         - targetUserId
@@ -794,10 +1642,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -813,6 +1657,329 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+    TeamTodosCreateInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creator:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutCreateTeamTodosInput"
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutTodosInput"
+      required:
+        - name
+        - creator
+        - team
+    TeamTodosUpdateInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        creator:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutCreateTeamTodosNestedIn\
+            put"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutTodosNestedInput"
+    TeamTodosCreateManyInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creatorId:
+          type: string
+        teamId:
+          type: string
+      required:
+        - name
+        - creatorId
+        - teamId
+    TeamTodosUpdateManyMutationInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+    TeamCreateInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutOwnedTeamsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutTeamInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+        - createdBy
+    TeamUpdateInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdBy:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutOwnedTeamsNestedInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutTeamNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutTeamNestedInput"
+    TeamCreateManyInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdById:
+          type: string
+      required:
+        - name
+        - createdById
+    TeamUpdateManyMutationInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+    TeamMemberCreateInput:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutMembersInput"
+        user:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutTeamMemberInput"
+      required:
+        - team
+        - user
+    TeamMemberUpdateInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutMembersNestedInput"
+        user:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutTeamMemberNestedInput"
+    TeamMemberCreateManyInput:
+      type: object
+      properties:
+        id:
+          type: string
+        teamId:
+          type: string
+        userId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - teamId
+        - userId
+    TeamMemberUpdateManyMutationInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+    TeamRequestCreateInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutRequestsInput"
+        requester:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutTeamRequestsInput"
+      required:
+        - team
+        - requester
+    TeamRequestUpdateInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutRequestsNestedInput"
+        requester:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutTeamRequestsNestedInput"
+    TeamRequestCreateManyInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - teamId
+        - requesterId
+    TeamRequestUpdateManyMutationInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
     StringFilter:
       type: object
       properties:
@@ -904,6 +2071,42 @@ components:
           $ref: "#/components/schemas/RequestWhereInput"
         none:
           $ref: "#/components/schemas/RequestWhereInput"
+    TeamMemberListRelationFilter:
+      type: object
+      properties:
+        every:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        some:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        none:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+    TeamTodosListRelationFilter:
+      type: object
+      properties:
+        every:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        some:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        none:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+    TeamListRelationFilter:
+      type: object
+      properties:
+        every:
+          $ref: "#/components/schemas/TeamWhereInput"
+        some:
+          $ref: "#/components/schemas/TeamWhereInput"
+        none:
+          $ref: "#/components/schemas/TeamWhereInput"
+    TeamRequestListRelationFilter:
+      type: object
+      properties:
+        every:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        some:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        none:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
     SortOrderInput:
       type: object
       properties:
@@ -919,6 +2122,26 @@ components:
         _count:
           $ref: "#/components/schemas/SortOrder"
     RequestOrderByRelationAggregateInput:
+      type: object
+      properties:
+        _count:
+          $ref: "#/components/schemas/SortOrder"
+    TeamMemberOrderByRelationAggregateInput:
+      type: object
+      properties:
+        _count:
+          $ref: "#/components/schemas/SortOrder"
+    TeamTodosOrderByRelationAggregateInput:
+      type: object
+      properties:
+        _count:
+          $ref: "#/components/schemas/SortOrder"
+    TeamOrderByRelationAggregateInput:
+      type: object
+      properties:
+        _count:
+          $ref: "#/components/schemas/SortOrder"
+    TeamRequestOrderByRelationAggregateInput:
       type: object
       properties:
         _count:
@@ -1151,6 +2374,53 @@ components:
           $ref: "#/components/schemas/NestedEnumRequestStatusFilter"
         _max:
           $ref: "#/components/schemas/NestedEnumRequestStatusFilter"
+    TeamScalarRelationFilter:
+      type: object
+      properties:
+        is:
+          $ref: "#/components/schemas/TeamWhereInput"
+        isNot:
+          $ref: "#/components/schemas/TeamWhereInput"
+    EnumTeamRoleFilter:
+      type: object
+      properties:
+        equals:
+          $ref: "#/components/schemas/TeamRole"
+        in:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        notIn:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        not:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
+    EnumTeamRoleWithAggregatesFilter:
+      type: object
+      properties:
+        equals:
+          $ref: "#/components/schemas/TeamRole"
+        in:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        notIn:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        not:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/NestedEnumTeamRoleWithAggregatesFilter"
+        _count:
+          $ref: "#/components/schemas/NestedIntFilter"
+        _min:
+          $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
+        _max:
+          $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
     TodosCreateNestedManyWithoutUserInput:
       type: object
       properties:
@@ -1232,6 +2502,114 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestWhereUniqueInput"
+    TeamMemberCreateNestedManyWithoutUserInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyUserInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+    TeamTodosCreateNestedManyWithoutCreatorInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyCreatorInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+    TeamCreateNestedManyWithoutCreatedByInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+        createMany:
+          $ref: "#/components/schemas/TeamCreateManyCreatedByInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+    TeamRequestCreateNestedManyWithoutRequesterInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyRequesterInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
     TodosUncheckedCreateNestedManyWithoutUserInput:
       type: object
       properties:
@@ -1313,6 +2691,114 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestWhereUniqueInput"
+    TeamMemberUncheckedCreateNestedManyWithoutUserInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyUserInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+    TeamTodosUncheckedCreateNestedManyWithoutCreatorInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyCreatorInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+    TeamUncheckedCreateNestedManyWithoutCreatedByInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+        createMany:
+          $ref: "#/components/schemas/TeamCreateManyCreatedByInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+    TeamRequestUncheckedCreateNestedManyWithoutRequesterInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyRequesterInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
     StringFieldUpdateOperationsInput:
       type: object
       properties:
@@ -1532,6 +3018,286 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestScalarWhereInput"
+    TeamMemberUpdateManyWithoutUserNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutUserInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyUserInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutUserInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutUserInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+    TeamTodosUpdateManyWithoutCreatorNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutCreatorInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyCreatorInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutCreatorInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutCreatorInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+    TeamUpdateManyWithoutCreatedByNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpsertWithWhereUniqueWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpsertWithWhereUniqueWithoutCreatedByInput"
+        createMany:
+          $ref: "#/components/schemas/TeamCreateManyCreatedByInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithWhereUniqueWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpdateWithWhereUniqueWithoutCreatedByInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateManyWithWhereWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpdateManyWithWhereWithoutCreatedByInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereInput"
+    TeamRequestUpdateManyWithoutRequesterNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutRequesterInp\
+                ut"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutRequesterInp\
+                  ut"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyRequesterInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutRequesterInp\
+                ut"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutRequesterInp\
+                  ut"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutRequesterInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
     TodosUncheckedUpdateManyWithoutUserNestedInput:
       type: object
       properties:
@@ -1739,6 +3505,286 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestScalarWhereInput"
+    TeamMemberUncheckedUpdateManyWithoutUserNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutUserInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutUserInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyUserInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutUserInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutUserInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+    TeamTodosUncheckedUpdateManyWithoutCreatorNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutCreatorInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutCreatorInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyCreatorInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutCreatorInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutCreatorInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+    TeamUncheckedUpdateManyWithoutCreatedByNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateOrConnectWithoutCreatedByInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpsertWithWhereUniqueWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpsertWithWhereUniqueWithoutCreatedByInput"
+        createMany:
+          $ref: "#/components/schemas/TeamCreateManyCreatedByInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithWhereUniqueWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpdateWithWhereUniqueWithoutCreatedByInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateManyWithWhereWithoutCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamUpdateManyWithWhereWithoutCreatedByInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereInput"
+    TeamRequestUncheckedUpdateManyWithoutRequesterNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutRequesterInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutRequesterInp\
+                ut"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutRequesterInp\
+                  ut"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyRequesterInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutRequesterInp\
+                ut"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutRequesterInp\
+                  ut"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutRequesterInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
     UserCreateNestedOneWithoutTodosInput:
       type: object
       properties:
@@ -1843,6 +3889,790 @@ components:
                 t"
             - $ref: "#/components/schemas/UserUpdateWithoutReceivedRequestsInput"
             - $ref: "#/components/schemas/UserUncheckedUpdateWithoutReceivedRequestsInput"
+    UserCreateNestedOneWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutCreateTeamTodosInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutCreateTeamTodosInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+    TeamCreateNestedOneWithoutTodosInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutTodosInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutTodosInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+    UserUpdateOneRequiredWithoutCreateTeamTodosNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutCreateTeamTodosInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutCreateTeamTodosInput"
+        upsert:
+          $ref: "#/components/schemas/UserUpsertWithoutCreateTeamTodosInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateToOneWithWhereWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUpdateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutCreateTeamTodosInput"
+    TeamUpdateOneRequiredWithoutTodosNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutTodosInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutTodosInput"
+        upsert:
+          $ref: "#/components/schemas/TeamUpsertWithoutTodosInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateToOneWithWhereWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUpdateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutTodosInput"
+    UserCreateNestedOneWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutOwnedTeamsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutOwnedTeamsInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+    TeamMemberCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+    TeamTodosCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+    TeamRequestCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+    TeamMemberUncheckedCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+    TeamTodosUncheckedCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+    TeamRequestUncheckedCreateNestedManyWithoutTeamInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyTeamInputEnvelope"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+    UserUpdateOneRequiredWithoutOwnedTeamsNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutOwnedTeamsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutOwnedTeamsInput"
+        upsert:
+          $ref: "#/components/schemas/UserUpsertWithoutOwnedTeamsInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateToOneWithWhereWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUpdateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutOwnedTeamsInput"
+    TeamMemberUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+    TeamTodosUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+    TeamRequestUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+    TeamMemberUncheckedUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamMemberCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+    TeamTodosUncheckedUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamTodosCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+    TeamRequestUncheckedUpdateManyWithoutTeamNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+        connectOrCreate:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateOrConnectWithoutTeamInput"
+        upsert:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpsertWithWhereUniqueWithoutTeamInput"
+        createMany:
+          $ref: "#/components/schemas/TeamRequestCreateManyTeamInputEnvelope"
+        set:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        disconnect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        delete:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        connect:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateWithWhereUniqueWithoutTeamInput"
+        updateMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestUpdateManyWithWhereWithoutTeamInput"
+        deleteMany:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+    TeamCreateNestedOneWithoutMembersInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutMembersInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutMembersInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+    UserCreateNestedOneWithoutTeamMemberInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamMemberInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutTeamMemberInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+    EnumTeamRoleFieldUpdateOperationsInput:
+      type: object
+      properties:
+        set:
+          $ref: "#/components/schemas/TeamRole"
+    TeamUpdateOneRequiredWithoutMembersNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutMembersInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutMembersInput"
+        upsert:
+          $ref: "#/components/schemas/TeamUpsertWithoutMembersInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateToOneWithWhereWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUpdateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutMembersInput"
+    UserUpdateOneRequiredWithoutTeamMemberNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamMemberInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutTeamMemberInput"
+        upsert:
+          $ref: "#/components/schemas/UserUpsertWithoutTeamMemberInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateToOneWithWhereWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamMemberInput"
+    TeamCreateNestedOneWithoutRequestsInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutRequestsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutRequestsInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+    UserCreateNestedOneWithoutTeamRequestsInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamRequestsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutTeamRequestsInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+    TeamUpdateOneRequiredWithoutRequestsNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutRequestsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/TeamCreateOrConnectWithoutRequestsInput"
+        upsert:
+          $ref: "#/components/schemas/TeamUpsertWithoutRequestsInput"
+        connect:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateToOneWithWhereWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUpdateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutRequestsInput"
+    UserUpdateOneRequiredWithoutTeamRequestsNestedInput:
+      type: object
+      properties:
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamRequestsInput"
+        connectOrCreate:
+          $ref: "#/components/schemas/UserCreateOrConnectWithoutTeamRequestsInput"
+        upsert:
+          $ref: "#/components/schemas/UserUpsertWithoutTeamRequestsInput"
+        connect:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateToOneWithWhereWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamRequestsInput"
     NestedStringFilter:
       type: object
       properties:
@@ -2186,6 +5016,46 @@ components:
           $ref: "#/components/schemas/NestedEnumRequestStatusFilter"
         _max:
           $ref: "#/components/schemas/NestedEnumRequestStatusFilter"
+    NestedEnumTeamRoleFilter:
+      type: object
+      properties:
+        equals:
+          $ref: "#/components/schemas/TeamRole"
+        in:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        notIn:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        not:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
+    NestedEnumTeamRoleWithAggregatesFilter:
+      type: object
+      properties:
+        equals:
+          $ref: "#/components/schemas/TeamRole"
+        in:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        notIn:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRole"
+        not:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/NestedEnumTeamRoleWithAggregatesFilter"
+        _count:
+          $ref: "#/components/schemas/NestedIntFilter"
+        _min:
+          $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
+        _max:
+          $ref: "#/components/schemas/NestedEnumTeamRoleFilter"
     TodosCreateWithoutUserInput:
       type: object
       properties:
@@ -2244,8 +5114,6 @@ components:
       properties:
         id:
           type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2256,6 +5124,8 @@ components:
         updatedAt:
           type: string
           format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
         targetUser:
           $ref: "#/components/schemas/UserCreateNestedOneWithoutReceivedRequestsInput"
       required:
@@ -2266,10 +5136,6 @@ components:
       properties:
         id:
           type: string
-        targetUserId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2280,6 +5146,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        targetUserId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - targetUserId
         - status
@@ -2313,8 +5183,6 @@ components:
       properties:
         id:
           type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2325,6 +5193,8 @@ components:
         updatedAt:
           type: string
           format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
         requester:
           $ref: "#/components/schemas/UserCreateNestedOneWithoutSentRequestsInput"
       required:
@@ -2335,10 +5205,6 @@ components:
       properties:
         id:
           type: string
-        requesterId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2349,6 +5215,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - requesterId
         - status
@@ -2373,6 +5243,241 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/RequestCreateManyTargetUserInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamMemberCreateWithoutUserInput:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutMembersInput"
+      required:
+        - team
+    TeamMemberUncheckedCreateWithoutUserInput:
+      type: object
+      properties:
+        id:
+          type: string
+        teamId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - teamId
+    TeamMemberCreateOrConnectWithoutUserInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+      required:
+        - where
+        - create
+    TeamMemberCreateManyUserInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateManyUserInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateManyUserInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamTodosCreateWithoutCreatorInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutTodosInput"
+      required:
+        - name
+        - team
+    TeamTodosUncheckedCreateWithoutCreatorInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+      required:
+        - name
+        - teamId
+    TeamTodosCreateOrConnectWithoutCreatorInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+      required:
+        - where
+        - create
+    TeamTodosCreateManyCreatorInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateManyCreatorInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateManyCreatorInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamCreateWithoutCreatedByInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        members:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutTeamInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+    TeamUncheckedCreateWithoutCreatedByInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutTeamInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutTeamInpu\
+            t"
+      required:
+        - name
+    TeamCreateOrConnectWithoutCreatedByInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+      required:
+        - where
+        - create
+    TeamCreateManyCreatedByInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateManyCreatedByInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateManyCreatedByInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamRequestCreateWithoutRequesterInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+        team:
+          $ref: "#/components/schemas/TeamCreateNestedOneWithoutRequestsInput"
+      required:
+        - team
+    TeamRequestUncheckedCreateWithoutRequesterInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - teamId
+    TeamRequestCreateOrConnectWithoutRequesterInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+      required:
+        - where
+        - create
+    TeamRequestCreateManyRequesterInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateManyRequesterInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateManyRequesterInput"
         skipDuplicates:
           type: boolean
       required:
@@ -2522,18 +5627,6 @@ components:
           oneOf:
             - $ref: "#/components/schemas/StringFilter"
             - type: string
-        requesterId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        targetUserId:
-          oneOf:
-            - $ref: "#/components/schemas/StringFilter"
-            - type: string
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/EnumRequestStatusFilter"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - $ref: "#/components/schemas/StringNullableFilter"
@@ -2549,6 +5642,18 @@ components:
             - $ref: "#/components/schemas/DateTimeFilter"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        targetUserId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
     RequestUpsertWithWhereUniqueWithoutTargetUserInput:
       type: object
       properties:
@@ -2590,6 +5695,335 @@ components:
       required:
         - where
         - data
+    TeamMemberUpsertWithWhereUniqueWithoutUserInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateWithoutUserInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutUserInput"
+      required:
+        - where
+        - update
+        - create
+    TeamMemberUpdateWithWhereUniqueWithoutUserInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithoutUserInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateWithoutUserInput"
+      required:
+        - where
+        - data
+    TeamMemberUpdateManyWithWhereWithoutUserInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserInput"
+      required:
+        - where
+        - data
+    TeamMemberScalarWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        userId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/EnumTeamRoleFilter"
+            - $ref: "#/components/schemas/TeamRole"
+    TeamTodosUpsertWithWhereUniqueWithoutCreatorInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateWithoutCreatorInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutCreatorInput"
+      required:
+        - where
+        - update
+        - create
+    TeamTodosUpdateWithWhereUniqueWithoutCreatorInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithoutCreatorInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateWithoutCreatorInput"
+      required:
+        - where
+        - data
+    TeamTodosUpdateManyWithWhereWithoutCreatorInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorInput"
+      required:
+        - where
+        - data
+    TeamTodosScalarWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        completed:
+          oneOf:
+            - $ref: "#/components/schemas/BoolFilter"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+    TeamUpsertWithWhereUniqueWithoutCreatedByInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutCreatedByInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutCreatedByInput"
+      required:
+        - where
+        - update
+        - create
+    TeamUpdateWithWhereUniqueWithoutCreatedByInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutCreatedByInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutCreatedByInput"
+      required:
+        - where
+        - data
+    TeamUpdateManyWithWhereWithoutCreatedByInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByInput"
+      required:
+        - where
+        - data
+    TeamScalarWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamScalarWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamScalarWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        name:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+    TeamRequestUpsertWithWhereUniqueWithoutRequesterInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateWithoutRequesterInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutRequesterInput"
+      required:
+        - where
+        - update
+        - create
+    TeamRequestUpdateWithWhereUniqueWithoutRequesterInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithoutRequesterInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateWithoutRequesterInput"
+      required:
+        - where
+        - data
+    TeamRequestUpdateManyWithWhereWithoutRequesterInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterInput"
+      required:
+        - where
+        - data
+    TeamRequestScalarWhereInput:
+      type: object
+      properties:
+        AND:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+        OR:
+          type: array
+          items:
+            $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+        NOT:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+        id:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        message:
+          oneOf:
+            - $ref: "#/components/schemas/StringNullableFilter"
+            - type: string
+            - type: "null"
+        createdAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - $ref: "#/components/schemas/DateTimeFilter"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        requesterId:
+          oneOf:
+            - $ref: "#/components/schemas/StringFilter"
+            - type: string
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/EnumRequestStatusFilter"
+            - $ref: "#/components/schemas/RequestStatus"
     UserCreateWithoutTodosInput:
       type: object
       properties:
@@ -2603,6 +6037,14 @@ components:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
       required:
         - id
     UserUncheckedCreateWithoutTodosInput:
@@ -2620,6 +6062,16 @@ components:
         receivedRequests:
           $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
             put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
       required:
         - id
     UserCreateOrConnectWithoutTodosInput:
@@ -2677,6 +6129,14 @@ components:
           $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
     UserUncheckedUpdateWithoutTodosInput:
       type: object
       properties:
@@ -2695,6 +6155,16 @@ components:
         receivedRequests:
           $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
             put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
     UserCreateWithoutSentRequestsInput:
       type: object
       properties:
@@ -2708,6 +6178,14 @@ components:
           $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
       required:
         - id
     UserUncheckedCreateWithoutSentRequestsInput:
@@ -2724,6 +6202,16 @@ components:
         receivedRequests:
           $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
             put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
       required:
         - id
     UserCreateOrConnectWithoutSentRequestsInput:
@@ -2751,6 +6239,14 @@ components:
           $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
         sentRequests:
           $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
       required:
         - id
     UserUncheckedCreateWithoutReceivedRequestsInput:
@@ -2767,6 +6263,16 @@ components:
         sentRequests:
           $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutRequesterInp\
             ut"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
       required:
         - id
     UserCreateOrConnectWithoutReceivedRequestsInput:
@@ -2824,6 +6330,14 @@ components:
           $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
         receivedRequests:
           $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
     UserUncheckedUpdateWithoutSentRequestsInput:
       type: object
       properties:
@@ -2841,6 +6355,16 @@ components:
         receivedRequests:
           $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
             put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
     UserUpsertWithoutReceivedRequestsInput:
       type: object
       properties:
@@ -2884,6 +6408,14 @@ components:
           $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
         sentRequests:
           $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
     UserUncheckedUpdateWithoutReceivedRequestsInput:
       type: object
       properties:
@@ -2901,6 +6433,1245 @@ components:
         sentRequests:
           $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutRequesterNestedInp\
             ut"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
+    UserCreateWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
+      required:
+        - id
+    UserUncheckedCreateWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutRequesterInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
+      required:
+        - id
+    UserCreateOrConnectWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutCreateTeamTodosInput"
+      required:
+        - where
+        - create
+    TeamCreateWithoutTodosInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutOwnedTeamsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+        - createdBy
+    TeamUncheckedCreateWithoutTodosInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdById:
+          type: string
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutTeamInpu\
+            t"
+      required:
+        - name
+        - createdById
+    TeamCreateOrConnectWithoutTodosInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutTodosInput"
+      required:
+        - where
+        - create
+    UserUpsertWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutCreateTeamTodosInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutCreateTeamTodosInput"
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+      required:
+        - update
+        - create
+    UserUpdateToOneWithWhereWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutCreateTeamTodosInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutCreateTeamTodosInput"
+      required:
+        - data
+    UserUpdateWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
+    UserUncheckedUpdateWithoutCreateTeamTodosInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutRequesterNestedInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
+    TeamUpsertWithoutTodosInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutTodosInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutTodosInput"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+      required:
+        - update
+        - create
+    TeamUpdateToOneWithWhereWithoutTodosInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutTodosInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutTodosInput"
+      required:
+        - data
+    TeamUpdateWithoutTodosInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdBy:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutOwnedTeamsNestedInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutTeamNestedInput"
+    TeamUncheckedUpdateWithoutTodosInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdById:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutTeamNestedInpu\
+            t"
+    UserCreateWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
+      required:
+        - id
+    UserUncheckedCreateWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutRequesterInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
+      required:
+        - id
+    UserCreateOrConnectWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutOwnedTeamsInput"
+      required:
+        - where
+        - create
+    TeamMemberCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+        user:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutTeamMemberInput"
+      required:
+        - user
+    TeamMemberUncheckedCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - userId
+    TeamMemberCreateOrConnectWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - create
+    TeamMemberCreateManyTeamInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateManyTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateManyTeamInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamTodosCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creator:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutCreateTeamTodosInput"
+      required:
+        - name
+        - creator
+    TeamTodosUncheckedCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creatorId:
+          type: string
+      required:
+        - name
+        - creatorId
+    TeamTodosCreateOrConnectWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - create
+    TeamTodosCreateManyTeamInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateManyTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateManyTeamInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    TeamRequestCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+        requester:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutTeamRequestsInput"
+      required:
+        - requester
+    TeamRequestUncheckedCreateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - requesterId
+    TeamRequestCreateOrConnectWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - create
+    TeamRequestCreateManyTeamInputEnvelope:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateManyTeamInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateManyTeamInput"
+        skipDuplicates:
+          type: boolean
+      required:
+        - data
+    UserUpsertWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutOwnedTeamsInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutOwnedTeamsInput"
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+      required:
+        - update
+        - create
+    UserUpdateToOneWithWhereWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutOwnedTeamsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutOwnedTeamsInput"
+      required:
+        - data
+    UserUpdateWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
+    UserUncheckedUpdateWithoutOwnedTeamsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutRequesterNestedInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
+    TeamMemberUpsertWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateWithoutTeamInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - update
+        - create
+    TeamMemberUpdateWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamMemberUpdateManyWithWhereWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamTodosUpsertWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateWithoutTeamInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - update
+        - create
+    TeamTodosUpdateWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamTodosUpdateManyWithWhereWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamRequestUpsertWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateWithoutTeamInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedCreateWithoutTeamInput"
+      required:
+        - where
+        - update
+        - create
+    TeamRequestUpdateWithWhereUniqueWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateWithoutTeamInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamRequestUpdateManyWithWhereWithoutTeamInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestScalarWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestUpdateManyMutationInput"
+            - $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutTeamInput"
+      required:
+        - where
+        - data
+    TeamCreateWithoutMembersInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutOwnedTeamsInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+        - createdBy
+    TeamUncheckedCreateWithoutMembersInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdById:
+          type: string
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutTeamInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutTeamInpu\
+            t"
+      required:
+        - name
+        - createdById
+    TeamCreateOrConnectWithoutMembersInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutMembersInput"
+      required:
+        - where
+        - create
+    UserCreateWithoutTeamMemberInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestCreateNestedManyWithoutRequesterInput"
+      required:
+        - id
+    UserUncheckedCreateWithoutTeamMemberInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutRequesterInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
+            put"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedCreateNestedManyWithoutRequeste\
+            rInput"
+      required:
+        - id
+    UserCreateOrConnectWithoutTeamMemberInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamMemberInput"
+      required:
+        - where
+        - create
+    TeamUpsertWithoutMembersInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutMembersInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutMembersInput"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+      required:
+        - update
+        - create
+    TeamUpdateToOneWithWhereWithoutMembersInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutMembersInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutMembersInput"
+      required:
+        - data
+    TeamUpdateWithoutMembersInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdBy:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutOwnedTeamsNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutTeamNestedInput"
+    TeamUncheckedUpdateWithoutMembersInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdById:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutTeamNestedInpu\
+            t"
+    UserUpsertWithoutTeamMemberInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamMemberInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamMemberInput"
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+      required:
+        - update
+        - create
+    UserUpdateToOneWithWhereWithoutTeamMemberInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamMemberInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamMemberInput"
+      required:
+        - data
+    UserUpdateWithoutTeamMemberInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutRequesterNestedInput"
+    UserUncheckedUpdateWithoutTeamMemberInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutRequesterNestedInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
+            put"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
+        teamRequests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutRequesterNeste\
+            dInput"
+    TeamCreateWithoutRequestsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          $ref: "#/components/schemas/UserCreateNestedOneWithoutOwnedTeamsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutTeamInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+        - createdBy
+    TeamUncheckedCreateWithoutRequestsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdById:
+          type: string
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutTeamInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutTeamInput"
+      required:
+        - name
+        - createdById
+    TeamCreateOrConnectWithoutRequestsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutRequestsInput"
+      required:
+        - where
+        - create
+    UserCreateWithoutTeamRequestsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutRequesterInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestCreateNestedManyWithoutTargetUserInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosCreateNestedManyWithoutCreatorInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamCreateNestedManyWithoutCreatedByInput"
+      required:
+        - id
+    UserUncheckedCreateWithoutTeamRequestsInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedCreateNestedManyWithoutUserInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutRequesterInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedCreateNestedManyWithoutTargetUserIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedCreateNestedManyWithoutUserInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedCreateNestedManyWithoutCreatorInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedCreateNestedManyWithoutCreatedByInput"
+      required:
+        - id
+    UserCreateOrConnectWithoutTeamRequestsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereUniqueInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamRequestsInput"
+      required:
+        - where
+        - create
+    TeamUpsertWithoutRequestsInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutRequestsInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedCreateWithoutRequestsInput"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+      required:
+        - update
+        - create
+    TeamUpdateToOneWithWhereWithoutRequestsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamUpdateWithoutRequestsInput"
+            - $ref: "#/components/schemas/TeamUncheckedUpdateWithoutRequestsInput"
+      required:
+        - data
+    TeamUpdateWithoutRequestsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdBy:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutOwnedTeamsNestedInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutTeamNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutTeamNestedInput"
+    TeamUncheckedUpdateWithoutRequestsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        createdById:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutTeamNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutTeamNestedInput"
+    UserUpsertWithoutTeamRequestsInput:
+      type: object
+      properties:
+        update:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamRequestsInput"
+        create:
+          oneOf:
+            - $ref: "#/components/schemas/UserCreateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedCreateWithoutTeamRequestsInput"
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+      required:
+        - update
+        - create
+    UserUpdateToOneWithWhereWithoutTeamRequestsInput:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/UserWhereInput"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/UserUpdateWithoutTeamRequestsInput"
+            - $ref: "#/components/schemas/UserUncheckedUpdateWithoutTeamRequestsInput"
+      required:
+        - data
+    UserUpdateWithoutTeamRequestsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutRequesterNestedInput"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUpdateManyWithoutTargetUserNestedInput"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutCreatorNestedInput"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUpdateManyWithoutCreatedByNestedInput"
+    UserUncheckedUpdateWithoutTeamRequestsInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        todos:
+          $ref: "#/components/schemas/TodosUncheckedUpdateManyWithoutUserNestedInput"
+        sentRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutRequesterNestedInp\
+            ut"
+        receivedRequests:
+          $ref: "#/components/schemas/RequestUncheckedUpdateManyWithoutTargetUserNestedIn\
+            put"
+        teamMember:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutUserNestedInput"
+        createTeamTodos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutCreatorNestedInp\
+            ut"
+        ownedTeams:
+          $ref: "#/components/schemas/TeamUncheckedUpdateManyWithoutCreatedByNestedInput"
     TodosCreateManyUserInput:
       type: object
       properties:
@@ -2920,10 +7691,6 @@ components:
       properties:
         id:
           type: string
-        targetUserId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2934,6 +7701,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        targetUserId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - targetUserId
         - status
@@ -2942,10 +7713,6 @@ components:
       properties:
         id:
           type: string
-        requesterId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -2956,9 +7723,74 @@ components:
         updatedAt:
           type: string
           format: date-time
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
       required:
         - requesterId
         - status
+    TeamMemberCreateManyUserInput:
+      type: object
+      properties:
+        id:
+          type: string
+        teamId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - teamId
+    TeamTodosCreateManyCreatorInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+      required:
+        - name
+        - teamId
+    TeamCreateManyCreatedByInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - name
+    TeamRequestCreateManyRequesterInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - teamId
     TodosUpdateWithoutUserInput:
       type: object
       properties:
@@ -3026,10 +7858,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -3045,6 +7873,10 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         targetUser:
           $ref: "#/components/schemas/UserUpdateOneRequiredWithoutReceivedRequestsNestedI\
             nput"
@@ -3055,14 +7887,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        targetUserId:
-          oneOf:
-            - type: string
-            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -3078,6 +7902,14 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        targetUserId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
     RequestUncheckedUpdateManyWithoutRequesterInput:
       type: object
       properties:
@@ -3085,6 +7917,21 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
         targetUserId:
           oneOf:
             - type: string
@@ -3093,21 +7940,6 @@ components:
           oneOf:
             - $ref: "#/components/schemas/RequestStatus"
             - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
-        message:
-          oneOf:
-            - type: string
-            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
-            - type: "null"
-        createdAt:
-          oneOf:
-            - type: string
-              format: date-time
-            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
-        updatedAt:
-          oneOf:
-            - type: string
-              format: date-time
-            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
     RequestUpdateWithoutTargetUserInput:
       type: object
       properties:
@@ -3115,10 +7947,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -3134,6 +7962,10 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         requester:
           $ref: "#/components/schemas/UserUpdateOneRequiredWithoutSentRequestsNestedInput"
     RequestUncheckedUpdateWithoutTargetUserInput:
@@ -3143,14 +7975,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        requesterId:
-          oneOf:
-            - type: string
-            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -3166,6 +7990,14 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        requesterId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
     RequestUncheckedUpdateManyWithoutTargetUserInput:
       type: object
       properties:
@@ -3173,14 +8005,6 @@ components:
           oneOf:
             - type: string
             - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        requesterId:
-          oneOf:
-            - type: string
-            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
-        status:
-          oneOf:
-            - $ref: "#/components/schemas/RequestStatus"
-            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
         message:
           oneOf:
             - type: string
@@ -3196,6 +8020,527 @@ components:
             - type: string
               format: date-time
             - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        requesterId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+    TeamMemberUpdateWithoutUserInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutMembersNestedInput"
+    TeamMemberUncheckedUpdateWithoutUserInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+    TeamMemberUncheckedUpdateManyWithoutUserInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+    TeamTodosUpdateWithoutCreatorInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutTodosNestedInput"
+    TeamTodosUncheckedUpdateWithoutCreatorInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+    TeamTodosUncheckedUpdateManyWithoutCreatorInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+    TeamUpdateWithoutCreatedByInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUpdateManyWithoutTeamNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUpdateManyWithoutTeamNestedInput"
+    TeamUncheckedUpdateWithoutCreatedByInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        members:
+          $ref: "#/components/schemas/TeamMemberUncheckedUpdateManyWithoutTeamNestedInput"
+        todos:
+          $ref: "#/components/schemas/TeamTodosUncheckedUpdateManyWithoutTeamNestedInput"
+        requests:
+          $ref: "#/components/schemas/TeamRequestUncheckedUpdateManyWithoutTeamNestedInpu\
+            t"
+    TeamUncheckedUpdateManyWithoutCreatedByInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+    TeamRequestUpdateWithoutRequesterInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+        team:
+          $ref: "#/components/schemas/TeamUpdateOneRequiredWithoutRequestsNestedInput"
+    TeamRequestUncheckedUpdateWithoutRequesterInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+    TeamRequestUncheckedUpdateManyWithoutRequesterInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        teamId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+    TeamMemberCreateManyTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+      required:
+        - userId
+    TeamTodosCreateManyTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creatorId:
+          type: string
+      required:
+        - name
+        - creatorId
+    TeamRequestCreateManyTeamInput:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+      required:
+        - requesterId
+    TeamMemberUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+        user:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutTeamMemberNestedInput"
+    TeamMemberUncheckedUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        userId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+    TeamMemberUncheckedUpdateManyWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        userId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        role:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRole"
+            - $ref: "#/components/schemas/EnumTeamRoleFieldUpdateOperationsInput"
+    TeamTodosUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        creator:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutCreateTeamTodosNestedIn\
+            put"
+    TeamTodosUncheckedUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        creatorId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+    TeamTodosUncheckedUpdateManyWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        name:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        completed:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/BoolFieldUpdateOperationsInput"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        creatorId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+    TeamRequestUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+        requester:
+          $ref: "#/components/schemas/UserUpdateOneRequiredWithoutTeamRequestsNestedInput"
+    TeamRequestUncheckedUpdateWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        requesterId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
+    TeamRequestUncheckedUpdateManyWithoutTeamInput:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        message:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/NullableStringFieldUpdateOperationsInput"
+            - type: "null"
+        createdAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        updatedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - $ref: "#/components/schemas/DateTimeFieldUpdateOperationsInput"
+        requesterId:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/StringFieldUpdateOperationsInput"
+        status:
+          oneOf:
+            - $ref: "#/components/schemas/RequestStatus"
+            - $ref: "#/components/schemas/EnumRequestStatusFieldUpdateOperationsInput"
     UserDefaultArgs:
       type: object
       properties:
@@ -3203,6 +8548,13 @@ components:
           $ref: "#/components/schemas/UserSelect"
         include:
           $ref: "#/components/schemas/UserInclude"
+    TeamDefaultArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
     UserInclude:
       type: object
       properties:
@@ -3218,6 +8570,22 @@ components:
           oneOf:
             - type: boolean
             - $ref: "#/components/schemas/RequestFindManyArgs"
+        teamMember:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberFindManyArgs"
+        createTeamTodos:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosFindManyArgs"
+        ownedTeams:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamFindManyArgs"
+        teamRequests:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestFindManyArgs"
         _count:
           oneOf:
             - type: boolean
@@ -3240,6 +8608,62 @@ components:
           oneOf:
             - type: boolean
             - $ref: "#/components/schemas/UserDefaultArgs"
+    TeamTodosInclude:
+      type: object
+      properties:
+        creator:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+    TeamInclude:
+      type: object
+      properties:
+        createdBy:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        members:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberFindManyArgs"
+        todos:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosFindManyArgs"
+        requests:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestFindManyArgs"
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamCountOutputTypeDefaultArgs"
+    TeamMemberInclude:
+      type: object
+      properties:
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+        user:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+    TeamRequestInclude:
+      type: object
+      properties:
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+        requester:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
     UserCountOutputTypeSelect:
       type: object
       properties:
@@ -3249,11 +8673,33 @@ components:
           type: boolean
         receivedRequests:
           type: boolean
+        teamMember:
+          type: boolean
+        createTeamTodos:
+          type: boolean
+        ownedTeams:
+          type: boolean
+        teamRequests:
+          type: boolean
+    TeamCountOutputTypeSelect:
+      type: object
+      properties:
+        members:
+          type: boolean
+        todos:
+          type: boolean
+        requests:
+          type: boolean
     UserCountOutputTypeDefaultArgs:
       type: object
       properties:
         select:
           $ref: "#/components/schemas/UserCountOutputTypeSelect"
+    TeamCountOutputTypeDefaultArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamCountOutputTypeSelect"
     UserSelect:
       type: object
       properties:
@@ -3273,6 +8719,22 @@ components:
           oneOf:
             - type: boolean
             - $ref: "#/components/schemas/RequestFindManyArgs"
+        teamMember:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberFindManyArgs"
+        createTeamTodos:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosFindManyArgs"
+        ownedTeams:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamFindManyArgs"
+        teamRequests:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestFindManyArgs"
         _count:
           oneOf:
             - type: boolean
@@ -3299,6 +8761,12 @@ components:
       properties:
         id:
           type: boolean
+        message:
+          type: boolean
+        createdAt:
+          type: boolean
+        updatedAt:
+          type: boolean
         requester:
           oneOf:
             - type: boolean
@@ -3313,11 +8781,103 @@ components:
           type: boolean
         status:
           type: boolean
+    TeamTodosSelect:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        completed:
+          type: boolean
+        createdAt:
+          type: boolean
+        creator:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        creatorId:
+          type: boolean
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+        teamId:
+          type: boolean
+    TeamSelect:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        createdAt:
+          type: boolean
+        createdBy:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        createdById:
+          type: boolean
+        members:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberFindManyArgs"
+        todos:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosFindManyArgs"
+        requests:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestFindManyArgs"
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamCountOutputTypeDefaultArgs"
+    TeamMemberSelect:
+      type: object
+      properties:
+        id:
+          type: boolean
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+        teamId:
+          type: boolean
+        user:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        userId:
+          type: boolean
+        role:
+          type: boolean
+    TeamRequestSelect:
+      type: object
+      properties:
+        id:
+          type: boolean
         message:
           type: boolean
         createdAt:
           type: boolean
         updatedAt:
+          type: boolean
+        team:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamDefaultArgs"
+        teamId:
+          type: boolean
+        requester:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/UserDefaultArgs"
+        requesterId:
+          type: boolean
+        status:
           type: boolean
     UserCountAggregateInput:
       type: object
@@ -3388,17 +8948,17 @@ components:
       properties:
         id:
           type: boolean
-        requesterId:
-          type: boolean
-        targetUserId:
-          type: boolean
-        status:
-          type: boolean
         message:
           type: boolean
         createdAt:
           type: boolean
         updatedAt:
+          type: boolean
+        requesterId:
+          type: boolean
+        targetUserId:
+          type: boolean
+        status:
           type: boolean
         _all:
           type: boolean
@@ -3407,34 +8967,204 @@ components:
       properties:
         id:
           type: boolean
-        requesterId:
-          type: boolean
-        targetUserId:
-          type: boolean
-        status:
-          type: boolean
         message:
           type: boolean
         createdAt:
           type: boolean
         updatedAt:
+          type: boolean
+        requesterId:
+          type: boolean
+        targetUserId:
+          type: boolean
+        status:
           type: boolean
     RequestMaxAggregateInput:
       type: object
       properties:
         id:
           type: boolean
+        message:
+          type: boolean
+        createdAt:
+          type: boolean
+        updatedAt:
+          type: boolean
         requesterId:
           type: boolean
         targetUserId:
           type: boolean
         status:
           type: boolean
+    TeamTodosCountAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        completed:
+          type: boolean
+        createdAt:
+          type: boolean
+        creatorId:
+          type: boolean
+        teamId:
+          type: boolean
+        _all:
+          type: boolean
+    TeamTodosMinAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        completed:
+          type: boolean
+        createdAt:
+          type: boolean
+        creatorId:
+          type: boolean
+        teamId:
+          type: boolean
+    TeamTodosMaxAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        completed:
+          type: boolean
+        createdAt:
+          type: boolean
+        creatorId:
+          type: boolean
+        teamId:
+          type: boolean
+    TeamCountAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        createdAt:
+          type: boolean
+        createdById:
+          type: boolean
+        _all:
+          type: boolean
+    TeamMinAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        createdAt:
+          type: boolean
+        createdById:
+          type: boolean
+    TeamMaxAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        name:
+          type: boolean
+        createdAt:
+          type: boolean
+        createdById:
+          type: boolean
+    TeamMemberCountAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        teamId:
+          type: boolean
+        userId:
+          type: boolean
+        role:
+          type: boolean
+        _all:
+          type: boolean
+    TeamMemberMinAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        teamId:
+          type: boolean
+        userId:
+          type: boolean
+        role:
+          type: boolean
+    TeamMemberMaxAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        teamId:
+          type: boolean
+        userId:
+          type: boolean
+        role:
+          type: boolean
+    TeamRequestCountAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
         message:
           type: boolean
         createdAt:
           type: boolean
         updatedAt:
+          type: boolean
+        teamId:
+          type: boolean
+        requesterId:
+          type: boolean
+        status:
+          type: boolean
+        _all:
+          type: boolean
+    TeamRequestMinAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        message:
+          type: boolean
+        createdAt:
+          type: boolean
+        updatedAt:
+          type: boolean
+        teamId:
+          type: boolean
+        requesterId:
+          type: boolean
+        status:
+          type: boolean
+    TeamRequestMaxAggregateInput:
+      type: object
+      properties:
+        id:
+          type: boolean
+        message:
+          type: boolean
+        createdAt:
+          type: boolean
+        updatedAt:
+          type: boolean
+        teamId:
+          type: boolean
+        requesterId:
+          type: boolean
+        status:
           type: boolean
     AggregateUser:
       type: object
@@ -3541,12 +9271,6 @@ components:
       properties:
         id:
           type: string
-        requesterId:
-          type: string
-        targetUserId:
-          type: string
-        status:
-          $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -3557,6 +9281,12 @@ components:
         updatedAt:
           type: string
           format: date-time
+        requesterId:
+          type: string
+        targetUserId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
         _count:
           oneOf:
             - type: "null"
@@ -3571,11 +9301,203 @@ components:
             - $ref: "#/components/schemas/RequestMaxAggregateOutputType"
       required:
         - id
+        - createdAt
+        - updatedAt
         - requesterId
         - targetUserId
         - status
+    AggregateTeamTodos:
+      type: object
+      properties:
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosMaxAggregateOutputType"
+    TeamTodosGroupByOutputType:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        completed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        creatorId:
+          type: string
+        teamId:
+          type: string
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamTodosMaxAggregateOutputType"
+      required:
+        - id
+        - name
+        - completed
+        - createdAt
+        - creatorId
+        - teamId
+    AggregateTeam:
+      type: object
+      properties:
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMaxAggregateOutputType"
+    TeamGroupByOutputType:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        createdById:
+          type: string
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMaxAggregateOutputType"
+      required:
+        - id
+        - name
+        - createdAt
+        - createdById
+    AggregateTeamMember:
+      type: object
+      properties:
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberMaxAggregateOutputType"
+    TeamMemberGroupByOutputType:
+      type: object
+      properties:
+        id:
+          type: string
+        teamId:
+          type: string
+        userId:
+          type: string
+        role:
+          $ref: "#/components/schemas/TeamRole"
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamMemberMaxAggregateOutputType"
+      required:
+        - id
+        - teamId
+        - userId
+        - role
+    AggregateTeamRequest:
+      type: object
+      properties:
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestMaxAggregateOutputType"
+    TeamRequestGroupByOutputType:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        teamId:
+          type: string
+        requesterId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+        _count:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestCountAggregateOutputType"
+        _min:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestMinAggregateOutputType"
+        _max:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRequestMaxAggregateOutputType"
+      required:
+        - id
         - createdAt
         - updatedAt
+        - teamId
+        - requesterId
+        - status
     UserCountAggregateOutputType:
       type: object
       properties:
@@ -3686,28 +9608,28 @@ components:
       properties:
         id:
           type: integer
-        requesterId:
-          type: integer
-        targetUserId:
-          type: integer
-        status:
-          type: integer
         message:
           type: integer
         createdAt:
           type: integer
         updatedAt:
           type: integer
+        requesterId:
+          type: integer
+        targetUserId:
+          type: integer
+        status:
+          type: integer
         _all:
           type: integer
       required:
         - id
-        - requesterId
-        - targetUserId
-        - status
         - message
         - createdAt
         - updatedAt
+        - requesterId
+        - targetUserId
+        - status
         - _all
     RequestMinAggregateOutputType:
       type: object
@@ -3716,18 +9638,6 @@ components:
           oneOf:
             - type: "null"
             - type: string
-        requesterId:
-          oneOf:
-            - type: "null"
-            - type: string
-        targetUserId:
-          oneOf:
-            - type: "null"
-            - type: string
-        status:
-          oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -3742,6 +9652,18 @@ components:
             - type: "null"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - type: "null"
+            - type: string
+        targetUserId:
+          oneOf:
+            - type: "null"
+            - type: string
+        status:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/RequestStatus"
     RequestMaxAggregateOutputType:
       type: object
       properties:
@@ -3749,18 +9671,6 @@ components:
           oneOf:
             - type: "null"
             - type: string
-        requesterId:
-          oneOf:
-            - type: "null"
-            - type: string
-        targetUserId:
-          oneOf:
-            - type: "null"
-            - type: string
-        status:
-          oneOf:
-            - type: "null"
-            - $ref: "#/components/schemas/RequestStatus"
         message:
           oneOf:
             - type: "null"
@@ -3775,6 +9685,309 @@ components:
             - type: "null"
             - type: string
               format: date-time
+        requesterId:
+          oneOf:
+            - type: "null"
+            - type: string
+        targetUserId:
+          oneOf:
+            - type: "null"
+            - type: string
+        status:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/RequestStatus"
+    TeamTodosCountAggregateOutputType:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: integer
+        completed:
+          type: integer
+        createdAt:
+          type: integer
+        creatorId:
+          type: integer
+        teamId:
+          type: integer
+        _all:
+          type: integer
+      required:
+        - id
+        - name
+        - completed
+        - createdAt
+        - creatorId
+        - teamId
+        - _all
+    TeamTodosMinAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        completed:
+          oneOf:
+            - type: "null"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - type: "null"
+            - type: string
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+    TeamTodosMaxAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        completed:
+          oneOf:
+            - type: "null"
+            - type: boolean
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        creatorId:
+          oneOf:
+            - type: "null"
+            - type: string
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+    TeamCountAggregateOutputType:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: integer
+        createdAt:
+          type: integer
+        createdById:
+          type: integer
+        _all:
+          type: integer
+      required:
+        - id
+        - name
+        - createdAt
+        - createdById
+        - _all
+    TeamMinAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - type: "null"
+            - type: string
+    TeamMaxAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        name:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        createdById:
+          oneOf:
+            - type: "null"
+            - type: string
+    TeamMemberCountAggregateOutputType:
+      type: object
+      properties:
+        id:
+          type: integer
+        teamId:
+          type: integer
+        userId:
+          type: integer
+        role:
+          type: integer
+        _all:
+          type: integer
+      required:
+        - id
+        - teamId
+        - userId
+        - role
+        - _all
+    TeamMemberMinAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+        userId:
+          oneOf:
+            - type: "null"
+            - type: string
+        role:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRole"
+    TeamMemberMaxAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+        userId:
+          oneOf:
+            - type: "null"
+            - type: string
+        role:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/TeamRole"
+    TeamRequestCountAggregateOutputType:
+      type: object
+      properties:
+        id:
+          type: integer
+        message:
+          type: integer
+        createdAt:
+          type: integer
+        updatedAt:
+          type: integer
+        teamId:
+          type: integer
+        requesterId:
+          type: integer
+        status:
+          type: integer
+        _all:
+          type: integer
+      required:
+        - id
+        - message
+        - createdAt
+        - updatedAt
+        - teamId
+        - requesterId
+        - status
+        - _all
+    TeamRequestMinAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+        requesterId:
+          oneOf:
+            - type: "null"
+            - type: string
+        status:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/RequestStatus"
+    TeamRequestMaxAggregateOutputType:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: "null"
+            - type: string
+        message:
+          oneOf:
+            - type: "null"
+            - type: string
+        createdAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        updatedAt:
+          oneOf:
+            - type: "null"
+            - type: string
+              format: date-time
+        teamId:
+          oneOf:
+            - type: "null"
+            - type: string
+        requesterId:
+          oneOf:
+            - type: "null"
+            - type: string
+        status:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/RequestStatus"
     _Meta:
       type: object
       description: Meta information about the request or response
@@ -4380,6 +10593,758 @@ components:
           $ref: "#/components/schemas/RequestMinAggregateInput"
         _max:
           $ref: "#/components/schemas/RequestMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosCreateArgs:
+      type: object
+      required:
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        data:
+          $ref: "#/components/schemas/TeamTodosCreateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosCreateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamTodosCreateManyInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamTodosCreateManyInput"
+        skipDuplicates:
+          type: boolean
+          description: Do not insert records with unique fields or ID fields that already
+            exist.
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosFindUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosFindFirstArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosFindManyArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosUpdateArgs:
+      type: object
+      required:
+        - where
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        data:
+          $ref: "#/components/schemas/TeamTodosUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosUpdateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        data:
+          $ref: "#/components/schemas/TeamTodosUpdateManyMutationInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosUpsertArgs:
+      type: object
+      required:
+        - create
+        - update
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        create:
+          $ref: "#/components/schemas/TeamTodosCreateInput"
+        update:
+          $ref: "#/components/schemas/TeamTodosUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosDeleteUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        include:
+          $ref: "#/components/schemas/TeamTodosInclude"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosDeleteManyArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosCountArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamTodosSelect"
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosAggregateArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamTodosOrderByWithRelationInput"
+        cursor:
+          $ref: "#/components/schemas/TeamTodosWhereUniqueInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamTodosMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamTodosMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamTodosGroupByArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamTodosWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamTodosOrderByWithRelationInput"
+        by:
+          $ref: "#/components/schemas/TeamTodosScalarFieldEnum"
+        having:
+          $ref: "#/components/schemas/TeamTodosScalarWhereWithAggregatesInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamTodosCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamTodosMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamTodosMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamCreateArgs:
+      type: object
+      required:
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        data:
+          $ref: "#/components/schemas/TeamCreateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamCreateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamCreateManyInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamCreateManyInput"
+        skipDuplicates:
+          type: boolean
+          description: Do not insert records with unique fields or ID fields that already
+            exist.
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamFindUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamFindFirstArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamFindManyArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamUpdateArgs:
+      type: object
+      required:
+        - where
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        data:
+          $ref: "#/components/schemas/TeamUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamUpdateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        data:
+          $ref: "#/components/schemas/TeamUpdateManyMutationInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamUpsertArgs:
+      type: object
+      required:
+        - create
+        - update
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        create:
+          $ref: "#/components/schemas/TeamCreateInput"
+        update:
+          $ref: "#/components/schemas/TeamUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamDeleteUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        include:
+          $ref: "#/components/schemas/TeamInclude"
+        where:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamDeleteManyArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamCountArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamSelect"
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamAggregateArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamOrderByWithRelationInput"
+        cursor:
+          $ref: "#/components/schemas/TeamWhereUniqueInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamGroupByArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamOrderByWithRelationInput"
+        by:
+          $ref: "#/components/schemas/TeamScalarFieldEnum"
+        having:
+          $ref: "#/components/schemas/TeamScalarWhereWithAggregatesInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberCreateArgs:
+      type: object
+      required:
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        data:
+          $ref: "#/components/schemas/TeamMemberCreateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberCreateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamMemberCreateManyInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamMemberCreateManyInput"
+        skipDuplicates:
+          type: boolean
+          description: Do not insert records with unique fields or ID fields that already
+            exist.
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberFindUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberFindFirstArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberFindManyArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberUpdateArgs:
+      type: object
+      required:
+        - where
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        data:
+          $ref: "#/components/schemas/TeamMemberUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberUpdateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        data:
+          $ref: "#/components/schemas/TeamMemberUpdateManyMutationInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberUpsertArgs:
+      type: object
+      required:
+        - create
+        - update
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        create:
+          $ref: "#/components/schemas/TeamMemberCreateInput"
+        update:
+          $ref: "#/components/schemas/TeamMemberUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberDeleteUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        include:
+          $ref: "#/components/schemas/TeamMemberInclude"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberDeleteManyArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberCountArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamMemberSelect"
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberAggregateArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamMemberOrderByWithRelationInput"
+        cursor:
+          $ref: "#/components/schemas/TeamMemberWhereUniqueInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamMemberMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamMemberMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamMemberGroupByArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamMemberWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamMemberOrderByWithRelationInput"
+        by:
+          $ref: "#/components/schemas/TeamMemberScalarFieldEnum"
+        having:
+          $ref: "#/components/schemas/TeamMemberScalarWhereWithAggregatesInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamMemberCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamMemberMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamMemberMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestCreateArgs:
+      type: object
+      required:
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        data:
+          $ref: "#/components/schemas/TeamRequestCreateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestCreateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/TeamRequestCreateManyInput"
+            - type: array
+              items:
+                $ref: "#/components/schemas/TeamRequestCreateManyInput"
+        skipDuplicates:
+          type: boolean
+          description: Do not insert records with unique fields or ID fields that already
+            exist.
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestFindUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestFindFirstArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestFindManyArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestUpdateArgs:
+      type: object
+      required:
+        - where
+        - data
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        data:
+          $ref: "#/components/schemas/TeamRequestUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestUpdateManyArgs:
+      type: object
+      required:
+        - data
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        data:
+          $ref: "#/components/schemas/TeamRequestUpdateManyMutationInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestUpsertArgs:
+      type: object
+      required:
+        - create
+        - update
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        create:
+          $ref: "#/components/schemas/TeamRequestCreateInput"
+        update:
+          $ref: "#/components/schemas/TeamRequestUpdateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestDeleteUniqueArgs:
+      type: object
+      required:
+        - where
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        include:
+          $ref: "#/components/schemas/TeamRequestInclude"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestDeleteManyArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestCountArgs:
+      type: object
+      properties:
+        select:
+          $ref: "#/components/schemas/TeamRequestSelect"
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestAggregateArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamRequestOrderByWithRelationInput"
+        cursor:
+          $ref: "#/components/schemas/TeamRequestWhereUniqueInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamRequestMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamRequestMaxAggregateInput"
+        meta:
+          $ref: "#/components/schemas/_Meta"
+    TeamRequestGroupByArgs:
+      type: object
+      properties:
+        where:
+          $ref: "#/components/schemas/TeamRequestWhereInput"
+        orderBy:
+          $ref: "#/components/schemas/TeamRequestOrderByWithRelationInput"
+        by:
+          $ref: "#/components/schemas/TeamRequestScalarFieldEnum"
+        having:
+          $ref: "#/components/schemas/TeamRequestScalarWhereWithAggregatesInput"
+        take:
+          type: integer
+        skip:
+          type: integer
+        _count:
+          oneOf:
+            - type: boolean
+            - $ref: "#/components/schemas/TeamRequestCountAggregateInput"
+        _min:
+          $ref: "#/components/schemas/TeamRequestMinAggregateInput"
+        _max:
+          $ref: "#/components/schemas/TeamRequestMaxAggregateInput"
         meta:
           $ref: "#/components/schemas/_Meta"
 paths:
@@ -6390,6 +13355,2690 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RequestGroupByArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/create:
+    post:
+      operationId: createTeamTodos
+      description: Create a new TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamTodosCreateArgs"
+  /teamTodos/createMany:
+    post:
+      operationId: createManyTeamTodos
+      description: Create several TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamTodosCreateManyArgs"
+  /teamTodos/findUnique:
+    get:
+      operationId: findUniqueTeamTodos
+      description: Find one unique TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosFindUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/findFirst:
+    get:
+      operationId: findFirstTeamTodos
+      description: Find the first TeamTodos matching the given condition
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosFindFirstArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/findMany:
+    get:
+      operationId: findManyTeamTodos
+      description: Find a list of TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosFindManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/update:
+    patch:
+      operationId: updateTeamTodos
+      description: Update a TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamTodosUpdateArgs"
+  /teamTodos/updateMany:
+    patch:
+      operationId: updateManyTeamTodos
+      description: Update TeamTodoss matching the given condition
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamTodosUpdateManyArgs"
+  /teamTodos/upsert:
+    post:
+      operationId: upsertTeamTodos
+      description: Upsert a TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamTodosUpsertArgs"
+  /teamTodos/delete:
+    delete:
+      operationId: deleteTeamTodos
+      description: Delete one unique TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosDeleteUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/deleteMany:
+    delete:
+      operationId: deleteManyTeamTodos
+      description: Delete TeamTodoss matching the given condition
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosDeleteManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/count:
+    get:
+      operationId: countTeamTodos
+      description: Find a list of TeamTodos
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    oneOf:
+                      - type: integer
+                      - $ref: "#/components/schemas/TeamTodosCountAggregateOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosCountArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/aggregate:
+    get:
+      operationId: aggregateTeamTodos
+      description: Aggregate TeamTodoss
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AggregateTeamTodos"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosAggregateArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamTodos/groupBy:
+    get:
+      operationId: groupByTeamTodos
+      description: Group TeamTodoss by fields
+      tags:
+        - teamTodos
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamTodosGroupByOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamTodosGroupByArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/create:
+    post:
+      operationId: createTeam
+      description: Create a new Team
+      tags:
+        - team
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamCreateArgs"
+  /team/createMany:
+    post:
+      operationId: createManyTeam
+      description: Create several Team
+      tags:
+        - team
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamCreateManyArgs"
+  /team/findUnique:
+    get:
+      operationId: findUniqueTeam
+      description: Find one unique Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamFindUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/findFirst:
+    get:
+      operationId: findFirstTeam
+      description: Find the first Team matching the given condition
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamFindFirstArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/findMany:
+    get:
+      operationId: findManyTeam
+      description: Find a list of Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamFindManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/update:
+    patch:
+      operationId: updateTeam
+      description: Update a Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamUpdateArgs"
+  /team/updateMany:
+    patch:
+      operationId: updateManyTeam
+      description: Update Teams matching the given condition
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamUpdateManyArgs"
+  /team/upsert:
+    post:
+      operationId: upsertTeam
+      description: Upsert a Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamUpsertArgs"
+  /team/delete:
+    delete:
+      operationId: deleteTeam
+      description: Delete one unique Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Team"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamDeleteUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/deleteMany:
+    delete:
+      operationId: deleteManyTeam
+      description: Delete Teams matching the given condition
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamDeleteManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/count:
+    get:
+      operationId: countTeam
+      description: Find a list of Team
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    oneOf:
+                      - type: integer
+                      - $ref: "#/components/schemas/TeamCountAggregateOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamCountArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/aggregate:
+    get:
+      operationId: aggregateTeam
+      description: Aggregate Teams
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AggregateTeam"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamAggregateArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /team/groupBy:
+    get:
+      operationId: groupByTeam
+      description: Group Teams by fields
+      tags:
+        - team
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamGroupByOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamGroupByArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/create:
+    post:
+      operationId: createTeamMember
+      description: Create a new TeamMember
+      tags:
+        - teamMember
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamMemberCreateArgs"
+  /teamMember/createMany:
+    post:
+      operationId: createManyTeamMember
+      description: Create several TeamMember
+      tags:
+        - teamMember
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamMemberCreateManyArgs"
+  /teamMember/findUnique:
+    get:
+      operationId: findUniqueTeamMember
+      description: Find one unique TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberFindUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/findFirst:
+    get:
+      operationId: findFirstTeamMember
+      description: Find the first TeamMember matching the given condition
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberFindFirstArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/findMany:
+    get:
+      operationId: findManyTeamMember
+      description: Find a list of TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberFindManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/update:
+    patch:
+      operationId: updateTeamMember
+      description: Update a TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamMemberUpdateArgs"
+  /teamMember/updateMany:
+    patch:
+      operationId: updateManyTeamMember
+      description: Update TeamMembers matching the given condition
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamMemberUpdateManyArgs"
+  /teamMember/upsert:
+    post:
+      operationId: upsertTeamMember
+      description: Upsert a TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamMemberUpsertArgs"
+  /teamMember/delete:
+    delete:
+      operationId: deleteTeamMember
+      description: Delete one unique TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberDeleteUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/deleteMany:
+    delete:
+      operationId: deleteManyTeamMember
+      description: Delete TeamMembers matching the given condition
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberDeleteManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/count:
+    get:
+      operationId: countTeamMember
+      description: Find a list of TeamMember
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    oneOf:
+                      - type: integer
+                      - $ref: "#/components/schemas/TeamMemberCountAggregateOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberCountArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/aggregate:
+    get:
+      operationId: aggregateTeamMember
+      description: Aggregate TeamMembers
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AggregateTeamMember"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberAggregateArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamMember/groupBy:
+    get:
+      operationId: groupByTeamMember
+      description: Group TeamMembers by fields
+      tags:
+        - teamMember
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamMemberGroupByOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamMemberGroupByArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/create:
+    post:
+      operationId: createTeamRequest
+      description: Create a new TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamRequestCreateArgs"
+  /teamRequest/createMany:
+    post:
+      operationId: createManyTeamRequest
+      description: Create several TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamRequestCreateManyArgs"
+  /teamRequest/findUnique:
+    get:
+      operationId: findUniqueTeamRequest
+      description: Find one unique TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestFindUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/findFirst:
+    get:
+      operationId: findFirstTeamRequest
+      description: Find the first TeamRequest matching the given condition
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestFindFirstArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/findMany:
+    get:
+      operationId: findManyTeamRequest
+      description: Find a list of TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestFindManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/update:
+    patch:
+      operationId: updateTeamRequest
+      description: Update a TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamRequestUpdateArgs"
+  /teamRequest/updateMany:
+    patch:
+      operationId: updateManyTeamRequest
+      description: Update TeamRequests matching the given condition
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamRequestUpdateManyArgs"
+  /teamRequest/upsert:
+    post:
+      operationId: upsertTeamRequest
+      description: Upsert a TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamRequestUpsertArgs"
+  /teamRequest/delete:
+    delete:
+      operationId: deleteTeamRequest
+      description: Delete one unique TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/TeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestDeleteUniqueArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/deleteMany:
+    delete:
+      operationId: deleteManyTeamRequest
+      description: Delete TeamRequests matching the given condition
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/BatchPayload"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestDeleteManyArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/count:
+    get:
+      operationId: countTeamRequest
+      description: Find a list of TeamRequest
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    oneOf:
+                      - type: integer
+                      - $ref: "#/components/schemas/TeamRequestCountAggregateOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestCountArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/aggregate:
+    get:
+      operationId: aggregateTeamRequest
+      description: Aggregate TeamRequests
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AggregateTeamRequest"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestAggregateArgs"
+        - name: meta
+          in: query
+          description: Superjson serialization metadata for parameter "q"
+          content:
+            application/json:
+              schema: {}
+  /teamRequest/groupBy:
+    get:
+      operationId: groupByTeamRequest
+      description: Group TeamRequests by fields
+      tags:
+        - teamRequest
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TeamRequestGroupByOutputType"
+                    description: The Prisma response data serialized with superjson
+                  meta:
+                    $ref: "#/components/schemas/_Meta"
+                    description: The superjson serialization metadata for the "data" field
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Invalid request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is forbidden
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_Error"
+          description: Request is unprocessable due to validation errors
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Superjson-serialized Prisma query object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRequestGroupByArgs"
         - name: meta
           in: query
           description: Superjson serialization metadata for parameter "q"

--- a/prisma/migrations/20250505143511_add_team_request/migration.sql
+++ b/prisma/migrations/20250505143511_add_team_request/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum
+CREATE TYPE "TeamRole" AS ENUM ('MEMBER', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "TeamTodos" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "completed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "creatorId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+
+    CONSTRAINT "TeamTodos_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMember" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "TeamRole" NOT NULL DEFAULT 'MEMBER',
+
+    CONSTRAINT "TeamMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamRequest" (
+    "id" TEXT NOT NULL,
+    "message" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "requesterId" TEXT NOT NULL,
+    "status" "RequestStatus" NOT NULL DEFAULT 'pending',
+
+    CONSTRAINT "TeamRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_name_key" ON "Team"("name");
+
+-- AddForeignKey
+ALTER TABLE "TeamTodos" ADD CONSTRAINT "TeamTodos_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamTodos" ADD CONSTRAINT "TeamTodos_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMember" ADD CONSTRAINT "TeamMember_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMember" ADD CONSTRAINT "TeamMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamRequest" ADD CONSTRAINT "TeamRequest_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamRequest" ADD CONSTRAINT "TeamRequest_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,12 +23,21 @@ enum RequestStatus {
   rejected
 }
 
+enum TeamRole {
+  MEMBER
+  ADMIN
+}
+
 model User {
-  id               String    @id()
+  id               String        @id()
   name             String?
   todos            Todos[]
-  sentRequests     Request[] @relation("SentRequests")
-  receivedRequests Request[] @relation("ReceivedRequests")
+  sentRequests     Request[]     @relation("SentRequests")
+  receivedRequests Request[]     @relation("ReceivedRequests")
+  teamMember       TeamMember[]
+  createTeamTodos  TeamTodos[]   @relation("TeamTodoCreator")
+  ownedTeams       Team[]        @relation("OwnedTeams")
+  teamRequests     TeamRequest[]
 }
 
 model Todos {
@@ -42,12 +51,55 @@ model Todos {
 
 model Request {
   id           String        @id() @default(cuid())
+  message      String?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt()
   requester    User          @relation("SentRequests", fields: [requesterId], references: [id])
   requesterId  String
   targetUser   User          @relation("ReceivedRequests", fields: [targetUserId], references: [id])
   targetUserId String
   status       RequestStatus
-  message      String?
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt()
+}
+
+model TeamTodos {
+  id        String   @id() @default(cuid())
+  name      String
+  completed Boolean  @default(false)
+  createdAt DateTime @default(now())
+  creator   User     @relation("TeamTodoCreator", fields: [creatorId], references: [id])
+  creatorId String
+  team      Team     @relation(fields: [teamId], references: [id])
+  teamId    String
+}
+
+model Team {
+  id          String        @id() @default(cuid())
+  name        String        @unique()
+  createdAt   DateTime      @default(now())
+  createdBy   User          @relation("OwnedTeams", fields: [createdById], references: [id])
+  createdById String
+  members     TeamMember[]
+  todos       TeamTodos[]
+  requests    TeamRequest[]
+}
+
+model TeamMember {
+  id     String   @id() @default(cuid())
+  team   Team     @relation(fields: [teamId], references: [id])
+  teamId String
+  user   User     @relation(fields: [userId], references: [id])
+  userId String
+  role   TeamRole @default(MEMBER)
+}
+
+model TeamRequest {
+  id          String        @id() @default(cuid())
+  message     String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt()
+  team        Team          @relation(fields: [teamId], references: [id])
+  teamId      String
+  requester   User          @relation(fields: [requesterId], references: [id])
+  requesterId String
+  status      RequestStatus @default(pending)
 }

--- a/schema.zmodel
+++ b/schema.zmodel
@@ -30,15 +30,25 @@ datasource db {
 }
 
 model User {
-  id               String    @id
+  id               String        @id
   name             String?
+
   todos            Todos[]
-  sentRequests     Request[] @relation("SentRequests")
-  receivedRequests Request[] @relation("ReceivedRequests")
+
+  sentRequests     Request[]     @relation("SentRequests")
+  receivedRequests Request[]     @relation("ReceivedRequests")
+
+  teamMember       TeamMember[]
+  createTeamTodos  TeamTodos[]   @relation('TeamTodoCreator')
+  ownedTeams       Team[]        @relation('OwnedTeams')
+  teamRequests     TeamRequest[]
 
   @@deny('all', auth() == null)
+
   @@deny('create', true)
+
   @@allow('read', true)
+
   @@allow('update,delete', auth() == this)
 }
 
@@ -47,29 +57,39 @@ model Todos {
   name      String   @length(min: 1, max: 100)
   completed Boolean  @default(false)
   createdAt DateTime @default(now())
+
   user      User     @relation(fields: [userId], references: [id])
   userId    String
 
   @@deny('all', auth() == null)
+
   @@allow('create', auth() != null)
+
   @@allow('read,delete,update', auth().id == userId)
+
   @@allow('read',auth().id == userId ||user.receivedRequests?[requesterId == auth().id && status == 'approved'])
 }
 
 model Request {
   id           String        @id @default(cuid())
-  requester    User          @relation("SentRequests", fields: [requesterId], references: [id])
-  requesterId  String
-  targetUser   User          @relation("ReceivedRequests", fields: [targetUserId], references: [id])
-  targetUserId String
-  status       RequestStatus
   message      String?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
 
+  requester    User          @relation("SentRequests", fields: [requesterId], references: [id])
+  requesterId  String
+
+  targetUser   User          @relation("ReceivedRequests", fields: [targetUserId], references: [id])
+  targetUserId String
+
+  status       RequestStatus
+
   @@deny('all', auth() == null)
+
   @@allow('read', auth() == requester || auth() == targetUser)
+
   @@allow('create', auth() == requester)
+
   @@allow('update', auth() == targetUser && future().status != status)
 }
 
@@ -78,3 +98,84 @@ enum RequestStatus {
   approved
   rejected
 }
+
+model TeamTodos {
+  id        String   @id @default(cuid())
+  name      String   @length(min: 1, max: 100)
+  completed Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  creator   User     @relation("TeamTodoCreator", fields: [creatorId], references: [id])
+  creatorId String
+
+  team      Team     @relation(fields: [teamId], references: [id])
+  teamId    String
+
+  @@allow('create', team.members?[userId == auth().id])
+
+  @@allow('read', team.members?[userId == auth().id])
+
+  @@allow('update,delete', creator.id == auth().id || team.createdBy.id == auth().id)
+}
+
+model Team {
+  id          String        @id @default(cuid())
+  name        String        @unique
+  createdAt   DateTime      @default(now())
+
+  createdBy   User          @relation("OwnedTeams", fields: [createdById], references: [id])
+  createdById String
+
+  members     TeamMember[]
+  todos       TeamTodos[]
+  requests    TeamRequest[]
+
+  @@allow('create',auth() !=null)
+
+  @@allow('read', members?[userId == auth().id] || createdById == auth().id)
+
+  @@allow('update,delete', createdBy.id == auth().id)
+}
+
+model TeamMember {
+  id     String   @id @default(cuid())
+
+  team   Team     @relation(fields: [teamId], references: [id])
+  teamId String
+
+  user   User     @relation(fields: [userId], references: [id])
+  userId String
+
+  role   TeamRole @default(MEMBER)
+
+  @@allow('create', team.createdBy.id == auth().id )
+
+  @@allow('read,delete', team.createdBy.id == auth().id || user.id == auth().id)
+}
+
+enum TeamRole {
+  MEMBER
+  ADMIN
+}
+
+model TeamRequest {
+  id          String        @id @default(cuid())
+  message     String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  team        Team          @relation(fields: [teamId], references: [id])
+  teamId      String
+
+  requester   User          @relation(fields: [requesterId], references: [id])
+  requesterId String
+
+  status      RequestStatus @default(pending)
+
+  @@allow('create', auth() == requester)
+
+  @@allow('read', auth() == team.createdBy || auth() == requester)
+
+  @@allow('update', auth() == team.createdBy && future().status != status)
+}
+


### PR DESCRIPTION
# 添加了团队协作功能
- 实现了用户可以创建团队的功能，创建团队的用户即是团队的管理员
- 实现了用户对团队代办事项的管理，即是对团队代办事项进行增删改操作
- 实现了管理员可以向用户发送邀请请求的功能
- 实现了用户可以向团队发送加入申请的功能
![image](https://github.com/user-attachments/assets/26f0edce-e74d-4f4e-bf96-ed5478ea7c1a)
![image](https://github.com/user-attachments/assets/336cea3a-0ba4-48ef-82aa-5ac677a6e474)
![20250507153850](https://github.com/user-attachments/assets/80998ddd-4e60-446b-aa73-8298ff1280df)
![image](https://github.com/user-attachments/assets/2103bffb-f5e5-49f3-bd1b-3a4fda1eab41)

